### PR TITLE
Autopublish a docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,18 @@
+name: Build and publish a docker image
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  docker_publish:
+    name: Push Docker image to GitHub Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Build and publish a Docker image for ${{ github.repository }}
+        uses: macbre/push-to-ghcr@master
+        with:
+          image_name: ${{ github.repository }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,19 @@ Read more about validation here: [cuni.cz](https://cuni.cz/UK-7987.html)
 
 # Usage
 
+## TL;DR way with prebuilt docker
+
+First, pull the docker image:
+```sh
+docker pull ghcr.io/mff-cuni-cz/cuni-thesis-validator:latest
+```
+
+Run the verification:
+```sh
+cd path/to/thesis/directory/with/thesis/pdf
+docker run -v $PWD:/thesis ghcr.io/mff-cuni-cz/cuni-thesis-validator verify /thesis/thesis.pdf |grep validationReports
+```
+
 ## Building the container
 
 The docker image is built as such:
@@ -20,23 +33,16 @@ docker build -t thesis-validator .
 Once you are in the container run the verify script with your pdf as an single
 argument
 
-```
+```sh
 verify my-thesis.pdf
 ```
 
 The command will dump the verapdf output. To gather the result as a return code
 you need to do something like:
 
-```
+```sh
 verify my-thesis.pdf | grep 'isCompliant="true"'
 ```
 
-Note that this is highly dependent on the format of verapdf output and if 
-you find a better way, please feel free to report it here as an improvement.
-
-## TL;DR way with docker
-
-```sh
-cd path/to/thesis/directory/with/thesis/pdf
-docker run -v $PWD:/thesis thesis-validator verify /thesis/thesis.pdf |grep validationReports
-```
+Note that this is highly dependent on the format of verapdf output. If you find
+a better way, please feel free to report it here as an improvement.


### PR DESCRIPTION
Hi all,

This might simplify the use for everyone (to just `docker pull` → `docker run`).

A secondary reason is that I wanted to make the PDF/A verifier run in GitLab CI for `better-mff-thesis`. @jjonescz [just submitted a github actions autoverifier](https://github.com/exaexa/better-mff-thesis/pull/4), but I got serious trouble doing the same in GitLab CI, because the CI action now builds the image itself (and for building containers in gitlab you need to use docker-in-docker, which needs privileges, so it's not really available, esp. not on MFF gitlab :disappointed: ).

A config change in Settings→Actions→General is required for this to actually be able to push anything to ghcr:
![image](https://user-images.githubusercontent.com/271543/167293056-f05f32fd-ebf3-4d5b-801f-41d33d4eef83.png)
(might look a bit different in an organization)
If successful, the container should automagically appear in the Packages sidebar. (Unfortunately it doesn't seem to work from gitub-created forks though (githubs :roll_eyes:), so it can't be seen in my fork now. The leftover from the testing repo looks like this: https://github.com/exaexa/cuni-thesis-validator/pkgs/container/cuni-thesis-validator )

Thanks!
-mk