### PR TITLE
Changed Docker image version & file copy location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
-FROM java:jre-alpine
+FROM ibmjava:jre
 
 COPY verapdf/ /usr/bin/verapdf
 COPY verify /usr/bin/verify
-COPY UK-7987-version1-custom8.xml uk-profile.xml
+COPY UK-7987-version1-custom8.xml /opt/uk-profile.xml
 
 ENV PATH="/usr/bin/verapdf:${PATH}"
-
-

--- a/verify
+++ b/verify
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-verapdf --profile /uk-profile.xml $@
+verapdf --profile /opt/uk-profile.xml $@


### PR DESCRIPTION
The presented `java:jre-alpine` image is deprecated. So, I replaced it with an updated version of a Docker JRE image. The docker container works properly with this change.

I believe that it could fix #4, I am not 100 percent certain, though.

I changed a destination folder for the .xml profile as well, I think it is better when copied to the `/opt/` folder instead of copying to the root directly, if needed, I can revert this change.